### PR TITLE
revert to static dependencies

### DIFF
--- a/gkbus/__init__.py
+++ b/gkbus/__init__.py
@@ -2,6 +2,6 @@
 GKBus: High level automotive protocol library
 '''
 
-__version__ = '0.3.9'
+__version__ = '0.4.0'
 
 __all__ = ['__version__']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,6 @@ build-backend = "flit_core.buildapi"
 [project]
 name = "gkbus"
 authors = [{name = "Dante", email = "dante383@protonmail.com"}]
-version = "0.3.9"
-dynamic = ["description","dependencies"]
-
-[tool.setuptools.dynamic]
-dependencies = {file = ["requirements.txt"]}
+version = "0.4.0"
+dynamic = ["description"]
+dependencies = ["scapy==2.5.0", "pyserial==3.5"]


### PR DESCRIPTION
dymanic dependencies not supported in flit:
flit_core.config.ConfigError: flit only supports dynamic metadata for 'version' & 'description'