### PR TITLE
revert python to 3.10.11 to avoid tkinter tcl error with 3.10.17

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,10 +22,11 @@ jobs:
             echo "version=$buildversion" >> $GITHUB_ENV
 
       - name: Install Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.10.11'
           architecture: 'x64'
+          allow-prereleases: true
 
       - name: Install dependencies
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "gkbus"
-version = "0.4.71"
+version = "0.4.72"
 readme = "README.md"
 authors = [{name = "Dante", email = "dante383@protonmail.com"}]
 dynamic = ["description"]


### PR DESCRIPTION
enable 'allow-prereleases: true' to permit the GitHub action to download python from source rather than rely on the Azure cache where old versions are depreciated within a few months. 