### PR TITLE
revert scapy to version '2.5.0'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,11 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "gkbus"
-version = "0.4.72"
+version = "0.4.73"
 readme = "README.md"
 authors = [{name = "Dante", email = "dante383@protonmail.com"}]
 dynamic = ["description"]
-dependencies = ["scapy==2.6.1", "pyserial==3.5"]
+dependencies = ["scapy==2.5.0", "pyserial==3.5"]
 
 [project.optional-dependencies]
 lint = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pyserial==3.5
-scapy==2.6.1
+scapy==2.5.0
 typing_extensions==4.12.2


### PR DESCRIPTION
To avoid GUI launch failures with error: 
FileNotFoundError: Tcl data directory "C:\Program Files (x86)\GKFlasher\_tcl_data" not found.
[PYI-20332:ERROR] Failed to execute script 'pyi_rth__tkinter' due to unhandled exception!